### PR TITLE
Fix text sometimes being displayed as black

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -26,6 +26,7 @@ body, html, #app {
 
   font-family: sans-serif;
 
+  color: var(--text-white);
   background: var(--mute);
   box-sizing: border-box; }
 


### PR DESCRIPTION
Fixes #39.

There's not currently a particular case where any text is affected by this, but this gets rid of the potential for accidentally black-on-black text.