### PR TITLE
Add pinned message API

### DIFF
--- a/api.js
+++ b/api.js
@@ -78,9 +78,13 @@ module.exports = function attachAPI(app, {io, db}) {
     // Extra details for a channel - these aren't returned in the channel list API,
     // but are when a specific channel is fetched.
     channelDetail: async c => Object.assign(serialize.channelShort(c), {
-      pinnedMessages: await Promise.all(c.pinnedMessageIDs.map(
-        async id => serialize.message(await db.messages.findOne({_id: id}))
-      ))
+      // Null messages are filtered out, just in case there's a broken message ID in the
+      // pinned message list (e.g. because a message was deleted).
+      pinnedMessages: (
+        (await Promise.all(c.pinnedMessageIDs.map(id => db.messages.findOne({_id: id}))))
+          .filter(Boolean)
+          .map(serialize.message)
+      )
     })
   }
 


### PR DESCRIPTION
Towards #17.

Send a POST request to `/api/pin-message` including your session ID and the message you want to pin to add a message to its channel's pinned message list. Only administrators can pin messages.

Send a GET request to `/api/channel/:channelID` to get the list of pinned messages (which is not returned through `/api/channel-list`):

![Screenshot of outputted JSON](https://user-images.githubusercontent.com/9948030/33561364-6094e71a-d90a-11e7-99ba-d16b723c5dac.png)

This doesn't do anything on the client-side.