### PR TITLE
Add online offline status

### DIFF
--- a/api.js
+++ b/api.js
@@ -671,6 +671,15 @@ module.exports = async function attachAPI(app, {wss, db}) {
     }
   ])
 
+  app.get('/api/user-list', async (request, response) => {
+    const users = await db.users.find({})
+
+    response.status(200).end(JSON.stringify({
+      success: true,
+      users: await Promise.all(users.map(serialize.user))
+    }))
+  })
+
   app.get('/api/username-available/:username', [
     ...middleware.loadVarFromParams('username'),
 

--- a/site/js/SessionActor.js
+++ b/site/js/SessionActor.js
@@ -98,6 +98,12 @@ export default class SessionActor extends Actor {
     })
   }
 
+  bindToSocket(socket) {
+    socket.on('ping for data', () => {
+      socket.send('pong data', {sessionID: this.sessionID})
+    })
+  }
+
   async initialLoad() {
     // Load session IDs from LocalStorage, if it has that data.
     if ('sessionIDs' in localStorage) {

--- a/site/js/Socket.js
+++ b/site/js/Socket.js
@@ -16,7 +16,7 @@ export default class Socket {
 
   // Note: socket.io calls this `emit`.
   send(evt, data) {
-    if (evt !== 'ping') {
+    if (evt !== 'pong data') {
       console.info('socket.send[' + evt + ']::', data)
     }
 
@@ -75,7 +75,7 @@ export default class Socket {
       const messageHandler = message => {
         const { evt, data } = JSON.parse(message.data)
 
-        if (evt !== 'pong') {
+        if (evt !== 'ping for data') {
           console.info('socket[' + evt + ']::', data)
         }
 


### PR DESCRIPTION
Includes #62! Merge that one before this.

Fixes #63.

This adds a simple online/offline status system. Any serialized user will include whether the user is online or not (in the `online` field). In order to do this, I added a `sessionID` field to socket data; this is filled in by the client's `pong data` event, which is sent in response to the server's `ping for data` event. (`ping for data` is sent as soon as the socket connects, and on the ping interval.) In order to see if a user is online or not, the API simply checks for any socket whose session ID belongs to that user.