### PR TITLE
Remove message revisions API; update client for this

### DIFF
--- a/api.js
+++ b/api.js
@@ -78,16 +78,11 @@ module.exports = async function attachAPI(app, {wss, db}) {
       id: m._id,
       authorUsername: m.authorUsername,
       authorID: m.authorID,
+      text: m.text,
       date: m.date,
+      editDate: m.editDate,
       channelID: m.channelID,
-      revisions: await Promise.all(m.revisions.map(serialize.messageRevision)),
       reactions: m.reactions
-    }),
-
-    messageRevision: async r => ({
-      text: r.text,
-      signature: r.signature,
-      date: r.date
     }),
 
     user: async u => ({
@@ -350,7 +345,6 @@ module.exports = async function attachAPI(app, {wss, db}) {
   app.post('/api/send-message', [
     ...middleware.loadVarFromBody('text'),
     ...middleware.loadVarFromBody('channelID'),
-    ...middleware.loadVarFromBody('signature', false),
     ...middleware.loadVarFromBody('sessionID'),
     ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
 
@@ -360,15 +354,10 @@ module.exports = async function attachAPI(app, {wss, db}) {
       const message = await db.messages.insert({
         authorID: sessionUser._id,
         authorUsername: sessionUser.username,
+        text: request.body.text,
         date: Date.now(),
+        editDate: null,
         channelID: channelID,
-        revisions: [
-          {
-            text: request.body.text,
-            signature: request.body.signature,
-            date: Date.now()
-          }
-        ],
         reactions: {}
       })
 
@@ -496,11 +485,9 @@ module.exports = async function attachAPI(app, {wss, db}) {
       }
 
       const [ numAffected, newMessage ] = await db.messages.update({_id: oldMessage._id}, {
-        $push: {
-          revisions: {
-            text, signature,
-            date: Date.now()
-          }
+        $set: {
+          text,
+          editDate: Date.now()
         }
       }, {
         multi: false,

--- a/site/styles.css
+++ b/site/styles.css
@@ -391,6 +391,9 @@ body, html, #app {
       font-weight: bold;
       color: var(--text-red); }
 
+    .message-label {
+      color: var(--mute-lighter); }
+
 a {
   color: #E080FF;
   text-decoration: none; }


### PR DESCRIPTION
Fixes #73.

Edited messages still display "(Edited)" beside the content (now with the edit date as the title text), but you cannot click to view old revisions (which are no longer stored).

![Demo screenshot of "(Edited)" beside edited messages](https://user-images.githubusercontent.com/9948030/33809114-52073be2-dde9-11e7-92e8-f4e597a71ed5.png)
