### PR TITLE
Respond with channel ID in create-channel

### DIFF
--- a/api.js
+++ b/api.js
@@ -561,7 +561,7 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       response.status(201).end(JSON.stringify({
         success: true,
-        channel
+        channelID: channel._id
       }))
     }
   ])


### PR DESCRIPTION
Fixes #85.

Before, the channel wasn't even being serialized before being responded - yikes!

(Branch title gore.. :shipit:)