### PR TITLE
Delete message API

### DIFF
--- a/api.js
+++ b/api.js
@@ -573,6 +573,34 @@ module.exports = async function attachAPI(app, {wss, db}) {
     }
   ])
 
+  app.post('/api/delete-message', [
+    ...middleware.loadVarFromBody('sessionID'),
+    ...middleware.loadVarFromBody('messageID'),
+    ...middleware.getSessionUserFromID('sessionID', 'sessionUser'),
+    ...middleware.getMessageFromID('messageID', 'message'),
+
+    async (request, response) => {
+      const { message, sessionUser } = request[middleware.vars]
+
+      if (sessionUser._id !== message.authorID) {
+        if (sessionUser.permissionLevel !== 'admin') {
+          response.status(403).end(JSON.stringify({
+            error: 'you are not the owner of this message'
+          }))
+
+          return
+        }
+      }
+
+      await db.messages.remove({_id: message._id})
+
+      // We don't want to send back the message itself, obviously!
+      sendToAllSockets('deleted chat message', {messageID: message._id})
+
+      response.status(200).end(JSON.stringify({success: true}))
+    }
+  ])
+
   app.get('/api/message/:messageID', [
     ...middleware.loadVarFromParams('messageID'),
     ...middleware.getMessageFromID('messageID', 'message'),

--- a/site/js/MessagesActor.js
+++ b/site/js/MessagesActor.js
@@ -91,6 +91,14 @@ export default class MessagesActor extends Actor {
       // Display newly-edited message.
       await this.updateMessageContent(msg.message)
     })
+
+    socket.on('deleted chat message', async msg => {
+      if (typeof msg !== 'object') {
+        return
+      }
+
+      this.removeMessageEl(msg.messageID)
+    })
   }
 
   clear() {
@@ -196,20 +204,21 @@ export default class MessagesActor extends Actor {
       })
 
       this.formSubmitOverloadFn = async ({ evt, text }) => {
-        if (text.trim().length === 0) {
-          // TODO Delete message instead!
-          done(false)
-          alert('Deleting messages isn\'t a thing yet sorry')
-
-          return
-        }
+        let result
 
         done(true)
 
-        const result = await post('edit-message', {
-          sessionID: this.actors.session.sessionID,
-          text, messageID
-        }, this.actors.session.currentServerURL)
+        if (text.trim().length === 0) {
+          result = await post('delete-message', {
+            sessionID: this.actors.session.sessionID,
+            messageID
+          }, this.actors.session.currentServerURL)
+        } else {
+          result = await post('edit-message', {
+            sessionID: this.actors.session.sessionID,
+            text, messageID
+          }, this.actors.session.currentServerURL)
+        }
 
         if (result.success) {
           resolve(true)
@@ -288,6 +297,14 @@ export default class MessagesActor extends Actor {
       }
 
       el.appendChild(await this.buildMessageContent(message))
+    }
+  }
+
+  removeMessageEl(messageID) {
+    const el = document.getElementById('message-' + messageID)
+
+    if (el) {
+      el.remove()
     }
   }
 


### PR DESCRIPTION
Fixes #94. Towards #66.

This implements a new API for deleting messages:

`POST /api/delete-message {messageID, sessionID}`

A small client implementation is also included. It's basically only a reference for now, since the client is in the process of being rewritten (#77). Also, it does not follow the spec as described in #66 (i.e. no "message action" dropdown); rather, it replaces the error message that shows up when a message is edited and a zero-length input is entered.

Note that the client implementation does not give a way to delete someone else's message, but this can be tested through the console:

```js
fetch('/api/delete-message', {
  method: 'post',
  headers: {'Content-Type': 'application/json'},
  body: JSON.stringify({messageID: '...', sessionID: actors.session.sessionID})
})
```

Note also that the client implementation simply removes the message element; if that message was the only one in a group, the client *does not* consider this, and an empty message group is left. I didn't bother writing more than a basic implementation because the client is going to be rewritten; this is something to consider in the new client (@heyitsmeuralex).