### PR TITLE
Emit socket event on channel rename

### DIFF
--- a/api.js
+++ b/api.js
@@ -668,6 +668,10 @@ module.exports = async function attachAPI(app, {wss, db}) {
 
       await db.channels.update({_id: channelID}, {$set: {name}})
 
+      sendToAllSockets('renamed channel', {
+        channelID, newName: name
+      })
+
       response.status(200).end(JSON.stringify({
         success: true
       }))

--- a/site/js/ChannelsActor.js
+++ b/site/js/ChannelsActor.js
@@ -116,6 +116,14 @@ export default class ChannelsActor extends Actor {
     socket.on('created new channel', () => this.loadChannels())
 
     socket.on('deleted channel', () => this.loadChannels())
+
+    socket.on('renamed channel', msg => {
+      if (typeof msg !== 'object') {
+        return
+      }
+
+      this.renameChannel(msg.channelID, msg.newName)
+    })
   }
 
   getChannelByID(channelID) {
@@ -160,6 +168,7 @@ export default class ChannelsActor extends Actor {
 
     for (const channel of channels) {
       const el = document.createElement('li')
+      el.id = 'channel-list-item-' + channel.id
       el.classList.add('channel')
       el.appendChild(document.createTextNode('#' + channel.name))
 
@@ -176,5 +185,14 @@ export default class ChannelsActor extends Actor {
     }
 
     sidebarEl.appendChild(listEl)
+  }
+
+  renameChannel(channelID, newName) {
+    const el = document.getElementById('channel-list-item-' + channelID)
+
+    if (el) {
+      el.firstChild.remove()
+      el.appendChild(document.createTextNode('#' + newName))
+    }
   }
 }


### PR DESCRIPTION
Fixes #90. Towards #66.

This emits a socket event to all clients `renamed channel { channelID, newName }` when a channel is renamed.

There's also a small reference implementation for the client code to handle this event.