### PR TITLE
Delete channel API

### DIFF
--- a/site/js/ChannelsActor.js
+++ b/site/js/ChannelsActor.js
@@ -112,7 +112,10 @@ export default class ChannelsActor extends Actor {
 
   bindToSocket(socket) {
     this.socket = socket
+
     socket.on('created new channel', () => this.loadChannels())
+
+    socket.on('deleted channel', () => this.loadChannels())
   }
 
   getChannelByID(channelID) {


### PR DESCRIPTION
Fixes #97.

Adds a new channel for deleting APIs: `POST /api/delete-channel {channelID, sessionID}`

And a corresponding socket event: `deleted channel {channelID}`

Adds a quick change to the client to reload the channel list when a channel is deleted, though it should be noted that it, if the deleted channel was selected, a different channel won't automatically be selected.