### PR TITLE
Fix state.secure being reset to false

### DIFF
--- a/packages/client/src/components/sidebar-left.js
+++ b/packages/client/src/components/sidebar-left.js
@@ -118,7 +118,6 @@ const store = (state, emitter) => {
       }
 
       state.sidebar.channels = null
-      state.secure = false
 
       const sessionID = storage.get('sessionID@' + state.params.host)
       if (sessionID) {


### PR DESCRIPTION
This effectively reverts https://github.com/decent-chat/decent/commit/2c39f3cf5f731107f72300fe8f0d94a7f8f97033. Oh well.

Right now, switching between servers is kind of *really* broken; I found out while testing this. Fun.

@heyitsmeuralex Go to bed - *sleep* :tada: - after merging this!